### PR TITLE
Add --log-level flag

### DIFF
--- a/userspace/sysdig/sysdig.cpp
+++ b/userspace/sysdig/sysdig.cpp
@@ -250,6 +250,8 @@ static void usage()
 "                    environment from /proc instead of truncating to the first 4KiB\n"
 "                    This may fail for short-lived processes and in that case\n"
 "                    the truncated environment is used instead.\n"
+" --log-level=<trace|debug|info|notice|warning|error|critical|fatal>\n"
+"                    Select log level. Useful together with --debug.\n"
 " --list-markdown    like -l, but produces markdown output\n"
 " -m <url[,marathon_url]>, --mesos-api=<url[,marathon_url]>\n"
 "                    Enable Mesos support by connecting to the API server\n"
@@ -1078,6 +1080,7 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 		{"list-events", no_argument, 0, 'L' },
 		{"list-markdown", no_argument, 0, 0 },
 		{"libs-version", no_argument, 0, 0},
+		{"log-level", required_argument, 0, 0 },
 #ifndef MINIMAL_BUILD
 		{"mesos-api", required_argument, 0, 'm'},
 #endif // MINIMAL_BUILD
@@ -1511,6 +1514,36 @@ sysdig_init_res sysdig_init(int argc, char **argv)
 						printf("falcosecurity/libs version %s", FALCOSECURITY_LIBS_VERSION);
 						delete inspector;
 						return sysdig_init_res(EXIT_SUCCESS);
+					}
+					else if (optname == "log-level") {
+						if (string(optarg) == "fatal") {
+							inspector->set_min_log_severity(sinsp_logger::SEV_FATAL);
+						}
+						else if (string(optarg) == "critical") {
+							inspector->set_min_log_severity(sinsp_logger::SEV_CRITICAL);
+						}
+						else if (string(optarg) == "error") {
+							inspector->set_min_log_severity(sinsp_logger::SEV_ERROR);
+						}
+						else if (string(optarg) == "warning") {
+							inspector->set_min_log_severity(sinsp_logger::SEV_WARNING);
+						}
+						else if (string(optarg) == "notice") {
+							inspector->set_min_log_severity(sinsp_logger::SEV_NOTICE);
+						}
+						else if (string(optarg) == "info") {
+							inspector->set_min_log_severity(sinsp_logger::SEV_INFO);
+						}
+						else if (string(optarg) == "debug") {
+							inspector->set_min_log_severity(sinsp_logger::SEV_DEBUG);
+						}
+						else if (string(optarg) == "trace") {
+							inspector->set_min_log_severity(sinsp_logger::SEV_TRACE);
+						} else {
+							fprintf(stderr, "invalid log level %s\n", optarg);
+							delete inspector;
+							return sysdig_init_res(EXIT_FAILURE);
+						}
 					}
 					else if (optname == "list-chisels") {
 						vector<chisel_desc> chlist;


### PR DESCRIPTION
# Add --log-level flag

To debug problems with missing container metadata, it is useful to enable debugs and select the log-level.

## How to use

Use `-D` and `--log-level` together. For example:

```
sysdig -D --log-level=trace --bpf=/ebpf/sysdig-ebpf.o evt.type=execve -p"*{%container.id %container.image %proc.cmdline}"
```

## Testing done

I tested this on the 0.27.0 branch first. Example of commands:

```
# sysdig -D --log-level=xx
invalid log level xx
```

```
# sysdig -D --log-level=warning --bpf=/ebpf/sysdig-ebpf.o evt.type=execve -p"*{%container.id %container.image %proc.cmdline}"
```

```
# sysdig -D --log-level=debug --bpf=/ebpf/sysdig-ebpf.o evt.type=execve -p"*{%container.id %container.image %proc.cmdline}"
...
04-27 14:13:13.847061 cri_async (9c3993d24990): Source dequeued key
04-27 14:13:13.847851 cri (9c3993d24990): Status from ContainerStatus: ()
04-27 14:13:13.849512 cri_async (9c3993d24990): Parse successful, storing value
04-27 14:13:13.849531 cri_async (9c3993d24990): Source callback result=1
04-27 14:13:13.849630 notify_new_container (9c3993d24990): created CONTAINER_JSON event, queuing to inspector
```

Signed-off-by: Alban Crequy <albancrequy@microsoft.com>
